### PR TITLE
動かなくなってるので直す

### DIFF
--- a/asahi-ajax_more.user.js
+++ b/asahi-ajax_more.user.js
@@ -3,14 +3,14 @@
 // @description    朝日新聞の記事ページで「続きを読む」ボタンを押すとその場で全文を表示する
 // @version        1.1
 // @author         vzvu3k6k
-// @match          http://www.asahi.com/articles/*
-// @match          http://digital.asahi.com/articles/*
+// @match          https://www.asahi.com/articles/*
+// @match          https://digital.asahi.com/articles/*
 // @namespace      http://vzvu3k6k.tk/
 // @license        CC0
 // @grant          GM_xmlhttpRequest
 // ==/UserScript==
 
-var $moreButton = document.querySelector('.ReadMore a[href^="http://digital.asahi.com/articles/"]');
+var $moreButton = document.querySelector('.ReadMore a[href^="https://digital.asahi.com/articles/"]');
 var disable = false;
 
 $moreButton.addEventListener('click', function(event){
@@ -34,7 +34,7 @@ $moreButton.addEventListener('click', function(event){
           return;
         }
 
-        if(response.finalUrl === 'http://digital.asahi.com/notice/notice_ltov.html'){
+        if(response.finalUrl === 'https://digital.asahi.com/notice/notice_ltov.html'){
           fail('閲覧可能本数を超過しました');
           return;
         }

--- a/asahi-ajax_more.user.js
+++ b/asahi-ajax_more.user.js
@@ -7,7 +7,7 @@
 // @match          https://digital.asahi.com/articles/*
 // @namespace      http://vzvu3k6k.tk/
 // @license        CC0
-// @grant          GM_xmlhttpRequest
+// @grant          GM.xmlHttpRequest
 // ==/UserScript==
 
 var $moreButton = document.querySelector('.ReadMore a[href^="https://digital.asahi.com/articles/"]');
@@ -24,7 +24,7 @@ $moreButton.addEventListener('click', function(event){
     disable = true;
   };
 
-  GM_xmlhttpRequest({
+  GM.xmlHttpRequest({
     method: 'GET',
     url: $moreButton.href,
     onload: function(response){

--- a/asahi-ajax_more.user.js
+++ b/asahi-ajax_more.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
-// @name           asahi.com: Ajaxで「続きを読む」
-// @description    朝日新聞の記事ページで「続きを読む」ボタンを押すとその場で全文を表示する
+// @name           asahi.com: Ajaxで「全文を読む」
+// @description    朝日新聞の記事ページで「全文を読む」ボタンを押すとその場で全文を表示する
 // @version        1.1
 // @author         vzvu3k6k
 // @match          https://www.asahi.com/articles/*

--- a/asahi-ajax_more.user.js
+++ b/asahi-ajax_more.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           asahi.com: Ajaxで「全文を読む」
 // @description    朝日新聞の記事ページで「全文を読む」ボタンを押すとその場で全文を表示する
-// @version        1.1
+// @version        1.2
 // @author         vzvu3k6k
 // @match          https://www.asahi.com/articles/*
 // @match          https://digital.asahi.com/articles/*


### PR DESCRIPTION
Fixes #1 

- [x] URLがhttpからhttpsになっていたので更新する
- [x] Greasemonkey 4のAPIの変更に対応する
- [x] ボタンのラベルの変更に対応する

Chrome v70 + Tampermonkey v4.8とFirefox v64 + Greasemonkey v4.7で動作することを確認した。